### PR TITLE
refactor: string trim set true for whole schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1165,7 +1165,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
       "integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -1315,7 +1314,6 @@
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.5.32.tgz",
       "integrity": "sha512-lBV8D5S5UNlWihHYQkEebqQTRazm5SglwQ126ls03eeYk2NJN4P72udUxJtyuKSmSFKvhLeekfNoPcyFa3BNdQ==",
-      "dev": true,
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
@@ -1343,8 +1341,7 @@
     "@types/node": {
       "version": "14.14.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
-      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==",
-      "dev": true
+      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -2190,9 +2187,9 @@
       }
     },
     "bson": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -2941,9 +2938,9 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "denque": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -5840,9 +5837,9 @@
       }
     },
     "kareem": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
-      "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
+      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
     },
     "keyv": {
       "version": "3.1.0",
@@ -6172,33 +6169,46 @@
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "mongodb": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
-      "integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
+      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "require_optional": "^1.0.1",
+        "optional-require": "^1.1.8",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
+      },
+      "dependencies": {
+        "optional-require": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+          "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+          "requires": {
+            "require-at": "^1.0.6"
+          }
+        }
       }
     },
     "mongoose": {
-      "version": "5.10.11",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.10.11.tgz",
-      "integrity": "sha512-R5BFitKW94/S/Z48w+X+qi/eto66jWBcVEVA8nYVkBoBAPFGq7JSYP/0uso+ZHs+7XjSzTuui+SUllzxIrf9yA==",
+      "version": "5.13.15",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.15.tgz",
+      "integrity": "sha512-cxp1Gbb8yUWkaEbajdhspSaKzAvsIvOtRlYD87GN/P2QEUhpd6bIvebi36T6M0tIVAMauNaK9SPA055N3PwF8Q==",
       "requires": {
+        "@types/bson": "1.x || 4.0.x",
+        "@types/mongodb": "^3.5.27",
         "bson": "^1.1.4",
-        "kareem": "2.3.1",
-        "mongodb": "3.6.2",
+        "kareem": "2.3.2",
+        "mongodb": "3.7.3",
         "mongoose-legacy-pluralize": "1.0.2",
-        "mpath": "0.7.0",
-        "mquery": "3.2.2",
+        "mpath": "0.8.4",
+        "mquery": "3.2.5",
         "ms": "2.1.2",
+        "optional-require": "1.0.x",
         "regexp-clone": "1.0.0",
         "safe-buffer": "5.2.1",
-        "sift": "7.0.1",
+        "sift": "13.5.2",
         "sliced": "1.0.1"
       },
       "dependencies": {
@@ -6220,14 +6230,14 @@
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
     "mpath": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.7.0.tgz",
-      "integrity": "sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg=="
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
+      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
     },
     "mquery": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.2.tgz",
-      "integrity": "sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
+      "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
       "requires": {
         "bluebird": "3.5.1",
         "debug": "3.1.0",
@@ -6617,6 +6627,11 @@
       "requires": {
         "mimic-fn": "^2.1.0"
       }
+    },
+    "optional-require": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
+      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
     },
     "optionator": {
       "version": "0.9.1",
@@ -7229,6 +7244,11 @@
         }
       }
     },
+    "require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7240,15 +7260,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
-    },
-    "require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "requires": {
-        "resolve-from": "^2.0.0",
-        "semver": "^5.1.0"
-      }
     },
     "resolve": {
       "version": "1.15.1",
@@ -7275,11 +7286,6 @@
           "dev": true
         }
       }
-    },
-    "resolve-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -7636,9 +7642,9 @@
       "optional": true
     },
     "sift": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
-      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
+      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -7679,7 +7685,7 @@
     "sliced": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
+      "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -7832,7 +7838,7 @@
     "sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "helmet": "^4.1.1",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.20",
-    "mongoose": "^5.10.11",
+    "mongoose": "^5.13.7",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.0"
   },

--- a/src/database/model/ApiKey.ts
+++ b/src/database/model/ApiKey.ts
@@ -12,6 +12,7 @@ export default interface ApiKey extends Document {
   updatedAt?: Date;
 }
 
+Schema.Types.String.set('trim', true);
 const schema = new Schema(
   {
     key: {
@@ -34,20 +35,11 @@ const schema = new Schema(
       type: Schema.Types.Boolean,
       default: true,
     },
-    createdAt: {
-      type: Date,
-      required: true,
-      select: false,
-    },
-    updatedAt: {
-      type: Date,
-      required: true,
-      select: false,
-    },
   },
   {
     versionKey: false,
   },
 );
 
+schema.set('timestamps', true);
 export const ApiKeyModel = model<ApiKey>(DOCUMENT_NAME, schema, COLLECTION_NAME);

--- a/src/database/model/Blog.ts
+++ b/src/database/model/Blog.ts
@@ -26,19 +26,18 @@ export default interface Blog extends Document {
   updatedAt?: Date;
 }
 
+Schema.Types.String.set('trim', true);
 const schema = new Schema(
   {
     title: {
       type: Schema.Types.String,
       required: true,
       maxlength: 500,
-      trim: true,
     },
     description: {
       type: Schema.Types.String,
       required: true,
       maxlength: 2000,
-      trim: true,
     },
     text: {
       type: Schema.Types.String,
@@ -53,7 +52,7 @@ const schema = new Schema(
     tags: [
       {
         type: Schema.Types.String,
-        trim: true,
+
         uppercase: true,
       },
     ],
@@ -67,14 +66,12 @@ const schema = new Schema(
       type: Schema.Types.String,
       required: false,
       maxlength: 500,
-      trim: true,
     },
     blogUrl: {
       type: Schema.Types.String,
       required: true,
       unique: true,
       maxlength: 200,
-      trim: true,
     },
     likes: {
       type: Schema.Types.Number,
@@ -127,16 +124,6 @@ const schema = new Schema(
       required: true,
       select: false,
     },
-    createdAt: {
-      type: Date,
-      required: true,
-      select: false,
-    },
-    updatedAt: {
-      type: Date,
-      required: true,
-      select: false,
-    },
   },
   {
     versionKey: false,
@@ -146,4 +133,5 @@ const schema = new Schema(
   { weights: { title: 3, description: 1 }, background: false },
 );
 
+schema.set('timestamps', true);
 export const BlogModel = model<Blog>(DOCUMENT_NAME, schema, COLLECTION_NAME);

--- a/src/database/model/Keystore.ts
+++ b/src/database/model/Keystore.ts
@@ -13,6 +13,7 @@ export default interface Keystore extends Document {
   updatedAt?: Date;
 }
 
+Schema.Types.String.set('trim', true);
 const schema = new Schema(
   {
     client: {
@@ -32,16 +33,6 @@ const schema = new Schema(
       type: Schema.Types.Boolean,
       default: true,
     },
-    createdAt: {
-      type: Date,
-      required: true,
-      select: false,
-    },
-    updatedAt: {
-      type: Date,
-      required: true,
-      select: false,
-    },
   },
   {
     versionKey: false,
@@ -50,5 +41,5 @@ const schema = new Schema(
 
 schema.index({ client: 1, primaryKey: 1 });
 schema.index({ client: 1, primaryKey: 1, secondaryKey: 1 });
-
+schema.set('timestamps', true);
 export const KeystoreModel = model<Keystore>(DOCUMENT_NAME, schema, COLLECTION_NAME);

--- a/src/database/model/Role.ts
+++ b/src/database/model/Role.ts
@@ -17,6 +17,7 @@ export default interface Role extends Document {
   updatedAt?: Date;
 }
 
+Schema.Types.String.set('trim', true);
 const schema = new Schema(
   {
     code: {
@@ -28,20 +29,11 @@ const schema = new Schema(
       type: Schema.Types.Boolean,
       default: true,
     },
-    createdAt: {
-      type: Date,
-      required: true,
-      select: false,
-    },
-    updatedAt: {
-      type: Date,
-      required: true,
-      select: false,
-    },
   },
   {
     versionKey: false,
   },
 );
 
+schema.set('timestamps', true);
 export const RoleModel = model<Role>(DOCUMENT_NAME, schema, COLLECTION_NAME);

--- a/src/database/model/User.ts
+++ b/src/database/model/User.ts
@@ -16,19 +16,18 @@ export default interface User extends Document {
   updatedAt?: Date;
 }
 
+Schema.Types.String.set('trim', true);
 const schema = new Schema(
   {
     name: {
       type: Schema.Types.String,
       required: true,
-      trim: true,
       maxlength: 100,
     },
     email: {
       type: Schema.Types.String,
       required: true,
       unique: true,
-      trim: true,
       select: false,
     },
     password: {
@@ -37,7 +36,6 @@ const schema = new Schema(
     },
     profilePicUrl: {
       type: Schema.Types.String,
-      trim: true,
     },
     roles: {
       type: [
@@ -57,20 +55,11 @@ const schema = new Schema(
       type: Schema.Types.Boolean,
       default: true,
     },
-    createdAt: {
-      type: Date,
-      required: true,
-      select: false,
-    },
-    updatedAt: {
-      type: Date,
-      required: true,
-      select: false,
-    },
   },
   {
     versionKey: false,
   },
 );
 
+schema.set('timestamps', true);
 export const UserModel = model<User>(DOCUMENT_NAME, schema, COLLECTION_NAME);

--- a/src/database/repository/BlogRepo.ts
+++ b/src/database/repository/BlogRepo.ts
@@ -17,7 +17,7 @@ export default class BlogRepo {
   }
 
   public static update(blog: Blog): Promise<any> {
-    // blog.updatedAt = new Date();
+    blog.updatedAt = new Date();
     return BlogModel.updateOne({ _id: blog._id }, { $set: { ...blog } })
       .lean<Blog>()
       .exec();

--- a/src/database/repository/BlogRepo.ts
+++ b/src/database/repository/BlogRepo.ts
@@ -17,7 +17,7 @@ export default class BlogRepo {
   }
 
   public static update(blog: Blog): Promise<any> {
-    blog.updatedAt = new Date();
+    // blog.updatedAt = new Date();
     return BlogModel.updateOne({ _id: blog._id }, { $set: { ...blog } })
       .lean<Blog>()
       .exec();


### PR DESCRIPTION
1. mongoose is upgraded
2. timestamps set to true ( no need to create schema fields for createdAt and updatedAt)