### PR TITLE
Feat: add trending blogs feature and redis cache layer

### DIFF
--- a/src/cache/keys.ts
+++ b/src/cache/keys.ts
@@ -1,5 +1,6 @@
 export enum Key {
   BLOGS_LATEST = 'BLOGS_LATEST',
+  BLOGS_TRENDING = 'BLOGS_TRENDING',
 }
 
 export enum DynamicKey {

--- a/src/cache/query.ts
+++ b/src/cache/query.ts
@@ -55,7 +55,7 @@ export async function setList(
   expireAt: Date | null = null,
 ) {
   const multi = cache.multi();
-  const values: any[] = []
+  const values: any[] = [];
   for (const i in list) {
     values[i] = JSON.stringify(list[i]);
   }

--- a/src/cache/repository/BlogTrendingCache.ts
+++ b/src/cache/repository/BlogTrendingCache.ts
@@ -1,0 +1,17 @@
+import cache from '..';
+import { Key } from '../keys';
+
+async function incrementBlogView(blogId: string) {
+  return cache.zIncrBy(Key.BLOGS_TRENDING, 1, blogId);
+}
+
+async function getTrendingBlogIds(limit: number) {
+  return cache.zRangeWithScores(Key.BLOGS_TRENDING, 0, limit - 1, {
+    REV: true,
+  });
+}
+
+export default {
+  incrementBlogView,
+  getTrendingBlogIds,
+};

--- a/src/core/ApiError.ts
+++ b/src/core/ApiError.ts
@@ -23,7 +23,10 @@ export enum ErrorType {
 }
 
 export abstract class ApiError extends Error {
-  constructor(public type: ErrorType, public message: string = 'error') {
+  constructor(
+    public type: ErrorType,
+    public message: string = 'error',
+  ) {
     super(type);
   }
 

--- a/src/core/ApiResponse.ts
+++ b/src/core/ApiResponse.ts
@@ -97,7 +97,10 @@ export class FailureMsgResponse extends ApiResponse {
 }
 
 export class SuccessResponse<T> extends ApiResponse {
-  constructor(message: string, private data: T) {
+  constructor(
+    message: string,
+    private data: T,
+  ) {
     super(StatusCode.SUCCESS, ResponseStatus.SUCCESS, message);
   }
 

--- a/src/database/repository/BlogRepo.ts
+++ b/src/database/repository/BlogRepo.ts
@@ -185,6 +185,24 @@ async function searchLike(query: string, limit: number): Promise<Blog[]> {
     .exec();
 }
 
+async function findTrendingBlogs(
+  pageNumber: number,
+  limit: number,
+): Promise<Blog[]> {
+  return BlogModel.find({ status: true, isPublished: true })
+    .skip(limit * (pageNumber - 1))
+    .limit(limit)
+    .sort({ score: -1 })
+    .populate('author', AUTHOR_DETAIL)
+    .lean()
+    .exec();
+}
+async function findAllBlogsByIds(ids: string[]): Promise<Blog[]> {
+  return BlogModel.find({ _id: { $in: ids }, status: true, isPublished: true })
+    .select('-status -description')
+    .lean()
+    .exec();
+}
 export default {
   create,
   update,
@@ -205,4 +223,6 @@ export default {
   searchSimilarBlogs,
   search,
   searchLike,
+  findTrendingBlogs,
+  findAllBlogsByIds,
 };

--- a/src/routes/blog/index.ts
+++ b/src/routes/blog/index.ts
@@ -9,6 +9,7 @@ import { Types } from 'mongoose';
 import writer from './writer';
 import editor from './editor';
 import BlogCache from '../../cache/repository/BlogCache';
+import BlogTrendingCache from '../../cache/repository/BlogTrendingCache';
 
 const router = express.Router();
 
@@ -28,6 +29,10 @@ router.get(
     }
 
     if (!blog) throw new NotFoundError('Blog not found');
+
+    //Increase Blod Score/View Count
+    await BlogTrendingCache.incrementBlogView(blog._id.toString());
+
     return new SuccessResponse('success', blog).send(res);
   }),
 );
@@ -47,6 +52,9 @@ router.get(
     }
 
     if (!blog) throw new NotFoundError('Blog not found');
+
+    //Increase Blod Score/View Count - If Blog Found only
+    await BlogTrendingCache.incrementBlogView(blog._id.toString());
     return new SuccessResponse('success', blog).send(res);
   }),
 );

--- a/src/routes/blogs/index.ts
+++ b/src/routes/blogs/index.ts
@@ -8,6 +8,7 @@ import BlogRepo from '../../database/repository/BlogRepo';
 import { Types } from 'mongoose';
 import User from '../../database/model/User';
 import BlogsCache from '../../cache/repository/BlogsCache';
+import BlogTrendingCache from '../../cache/repository/BlogTrendingCache';
 
 const router = express.Router();
 
@@ -67,6 +68,44 @@ router.get(
     }
 
     return new SuccessResponse('success', blogs ? blogs : []).send(res);
+  }),
+);
+
+// GET /blogs/trending?limit=10&pageNumber=1
+router.get(
+  '/trending',
+  validator(schema.trending, ValidationSource.QUERY),
+  asyncHandler(async (req, res) => {
+    const limit = req.query.limit ? parseInt(req.query.limit as string) : 10;
+    // const pageNumber = req.query.pageNumber
+    //   ? parseInt(req.query.pageNumber as string)
+    //   : 1;
+
+    const trending = await BlogTrendingCache.getTrendingBlogIds(limit);
+
+    const blogIds = trending.map((oneItem) => {
+      return oneItem.value;
+    });
+
+    const allBlogs = await BlogRepo.findAllBlogsByIds(blogIds);
+    const blogMap = new Map(
+      allBlogs.map((eachBlog) => [eachBlog._id.toString(), eachBlog]),
+    );
+    //Format the Obtained Data by Views counts for trending
+    const formatedResponse = trending.map((oneItem) => {
+      const blog = blogMap.get(oneItem.value);
+      if (!blog) {
+        return null;
+      }
+      return {
+        ...blog,
+        views: oneItem.score,
+      };
+    });
+    const finalResponse = formatedResponse.filter((oneBlog) => {
+      return oneBlog !== null;
+    });
+    return new SuccessResponse('success', finalResponse).send(res);
   }),
 );
 

--- a/src/routes/blogs/schema.ts
+++ b/src/routes/blogs/schema.ts
@@ -15,4 +15,7 @@ export default {
   authorId: Joi.object().keys({
     id: JoiObjectId().required(),
   }),
+  trending: Joi.object().keys({
+    limit: Joi.number().optional().integer().min(1),
+  }),
 };

--- a/tests/routes/blog/index/mock.ts
+++ b/tests/routes/blog/index/mock.ts
@@ -83,3 +83,11 @@ jest.mock('../../../../src/database/repository/BlogRepo', () => ({
   findPublishedByUrl: mockPublishedBlogFindByUrl,
   findInfoForPublishedById: mockPublishedBlogFindById,
 }));
+
+jest.mock('../../../../src/cache/repository/BlogTrendingCache', () => ({
+  __esModule: true,
+  default: {
+    incrementBlogView: jest.fn().mockResolvedValue(1),
+    getTrendingBlogIds: jest.fn().mockResolvedValue([]),
+  },
+}));


### PR DESCRIPTION
## Description:
This PR adds the "Trending Blogs" feature. Instead of saving every blog view directly to MongoDB (which can slow down the database), it tracks and ranks the most-viewed blogs quickly in Redis.

## Key Changes
- **Cache Layer:**
  - Added `BLOGS_TRENDING` key to `src/cache/keys.ts`.
  - Created `src/cache/repository/BlogTrendingCache.ts` file using `zIncrBy` and `zRangeWithScores` to track views and rankings.
- **Database Layer:**
  - Added `findAllBlogsByIds` in `src/database/repository/BlogRepo.ts` to fetch multiple blogs by ID efficiently.
- **Routes & Endpoints:**
  - Added the `GET /blogs/trending` API endpoint with validation schema for the limit.
  - Updated single-blog details endpoints (`/url` and `/id/:id`) to increment the Redis view count whenever a blog is opened.

## How to Test
- Spin up the app, increment views via `GET /blog/url?endpoint=your_blog`, and verify ranking via `GET /blogs/trending?limit=any_number`.

## Checklist
- [x] Prettier and ESLint check passed successfully.
- [x] All existing unit and integration tests passed (`npm test`).
- [x] Manual verification of Redis scoring and sorting works as expected.
- [x] Manually Tested all the testcases required for `/blogs/trending` query parameters.